### PR TITLE
sample pdf scrape using pdfquery python library

### DIFF
--- a/civic.json
+++ b/civic.json
@@ -1,5 +1,11 @@
 {
-    "thumbnailUrl": "http://upload.wikimedia.org/wikipedia/commons/d/d0/Msgpack-json_copy.png",
+    "thumbnailUrl": "",
+    "contributors" : [
+      "@talos",
+      "@aepyornis",
+      "@clhenrick",
+      "@romeboards"
+    ],
     "status": "Beta",
     "geography": "NYC",
     "name": "nyc-stabilization-unit-counts",

--- a/civic.json
+++ b/civic.json
@@ -1,0 +1,20 @@
+{
+    "thumbnailUrl": "http://upload.wikimedia.org/wikipedia/commons/d/d0/Msgpack-json_copy.png",
+    "status": "Beta",
+    "geography": "NYC",
+    "name": "nyc-stabilization-unit-counts",
+    "bornAt": "Code Across NYC 2015",
+    "politicalEntity":"",
+    "type": "Web & PDF scraper",
+    "needs": [
+      {"need" : "web interface"}
+    ],
+    "categories" : [
+      {"category":"Housing"},
+      {"category":"Rent Stabilization"},
+      {"category":"Department of Finance"},
+      {"category":"Tax Bills"},
+      {"category":"Gross Rent Income"},
+      {"category": "Open Data"}
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "nyc-stabilization-unit-counts",
+  "version": "0.1.0",
+  "description": "'Scraping NYC DOF tax documents and data'",
+  "main": "scrape.js",
+  "scripts": {
+    "test": "npm test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/talos/nyc-stabilization-unit-counts.git"
+  },
+  "keywords": [
+    "nyc",
+    "housing",
+    "dof",
+    "tax",
+    "data",
+    "buildings",
+    "rent stabilization",
+    "rent regulation"
+  ],
+  "author": "Chris Henrick <chrishenrick@gmail.com> (http://chrishenrick.com)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/talos/nyc-stabilization-unit-counts/issues"
+  },
+  "homepage": "https://github.com/talos/nyc-stabilization-unit-counts",
+  "dependencies": {
+    "pdf-text": "^0.4.0",
+    "underscore": "^1.8.2"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4
 requests
 lxml
+pdfquery

--- a/scrape-quarterly-pdf.py
+++ b/scrape-quarterly-pdf.py
@@ -1,0 +1,14 @@
+import pdfquery
+
+# load the pdf from file path
+pdf = pdfquery.PDFQuery('data/test.pdf')
+pdf.load()
+# find the anchor point of the "# Apts" label
+label = pdf.pq('LTTextLineHorizontal:contains("# Apts")')
+left_corner = float(label.attr('x0'))
+bottom_corner = float(label.attr('y0'))
+# grab the unit count below the # Apts label
+apt_count = pdf.pq('LTTextLineHorizontal:in_bbox("%s, %s, %s, %s")' % (left_corner, bottom_corner-20, left_corner+100, bottom_corner+10)).text()
+
+print apt_count
+

--- a/scrape.js
+++ b/scrape.js
@@ -1,0 +1,82 @@
+var pdfText = require('pdf-text')
+var _ = require('underscore');
+ 
+var pathToPdf = __dirname + "/" + process.argv[2];
+ 
+pdfText(pathToPdf, function(err, chunks) {
+    if (err) { console.log(err); }
+    console.log(chunks);
+    console.log(to_json(chunks));
+})
+ 
+function to_json(chunks) {
+  
+  var property_address_index;
+  var owner_name_index;
+  var bbl_index;
+  var rent_stab_index;
+  var rentStabilized = null;
+  var annual_tax_index;
+  var abatements = [];
+  var activityThrough;
+
+  _.each(chunks, function(element, i, list) {
+
+    if ( /\s*Property address:?\w?/i.test(element) ){
+      property_address_index = i;
+    } else if ( /\s*Owner name:?\s*/i.test(element) ) {
+        owner_name_index = i;
+    } else if ( /\s*Borough, block & lot:\s*/i.test(element) ) {
+        bbl_index = i;
+    } else if ( /\s*Housing-Rent Stabilization\s*/i.test(element) ) {
+      rentStabilized = i;
+    } else if (  /\s*J-?51\s*/i.test(element) ) {
+      abatements.push(element);
+    } else if ( /\s*4-?21\s*/.test(element) ) {
+      abatements.push(element);
+    } else if ( /\s*Annual property tax\w*/i.test(element)) {
+      annual_tax_index = i;
+    } else if ( /\s*Activity through\s*/.test(element)) {
+      activityThrough = chunks[i + 1];
+    }
+    else {}
+  });
+
+
+  var property = {
+    activityThrough: activityThrough,
+    ownerName: chunks[owner_name_index + 1],
+    bbl: chunks[bbl_index + 1],
+    units: (rentStabilized) ? chunks[rentStabilized + 1] : 0,
+    stabilized_amount: (rentStabilized) ? chunks[rentStabilized + 3] : 'n/a',
+    rentStabilized: (rentStabilized) ? true : false,
+    propertyAddress: get_property_address(),
+    annualTax: get_annual_tax(),
+    abatements: abatements
+  }
+
+    return property;
+
+  function get_annual_tax(){
+    var tax = chunks[annual_tax_index + 1];
+    if (/\s*\$\d+/.test(tax)) {
+      return tax;
+    } else {
+      return tax + chunks[annual_tax_index + 2]
+    }
+  }
+
+  function get_property_address () {
+    var address = '';
+    for (var p = (property_address_index + 1); p < bbl_index; p++) {
+      address += chunks[p];
+      address += ' '
+    }
+    return address;
+  }
+
+
+}
+
+
+


### PR DESCRIPTION
### Example Using PDFQuery

Right now this just grabs the # of units from the Quarterly Tax PDF document. It uses the "# Apt" label as a reference coordinate to draw a bounding box which selects the actual unit number below the label. This method could theoretically be used for other data in the PDF. Then each piece could be combined to create a dictionary and write to a CSV or JSON file.
